### PR TITLE
fix: add latestReviews resolver to reviews starter code

### DIFF
--- a/your-code-here/subgraph-reviews/resolvers.js
+++ b/your-code-here/subgraph-reviews/resolvers.js
@@ -1,9 +1,14 @@
 const resolvers = {
-  Mutation: {
-    submitReview(_, { review }, { dataSources }) {
-      const newReview = dataSources.reviewsAPI.submitReviewForLocation(review);
-      return { code: 200, success: true, message: 'success', review: newReview };
-    },
+  Query: {
+    latestReviews(_, __, {dataSources}) {
+      return dataSources.reviewsAPI.getLatestReviews();
+    }
   },
+  Mutation: {
+    submitReview(_, {review}, {dataSources}) {
+      const newReview = dataSources.reviewsAPI.submitReviewForLocation(review);
+      return {code: 200, success: true, message: 'success', review: newReview};
+    }
+  }
 };
 module.exports = resolvers;


### PR DESCRIPTION
- Add the `latestReviews` resolver to the reviews subgraph starter code