### PR TITLE
Added endOfLine auto

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -5,6 +5,12 @@
     ],
     "rules": {
         "react/react-in-jsx-scope": "off",
+        "prettier/prettier": [
+           "error",
+           {
+              "endOfLine": "auto"
+           }
+        ],
         "no-multi-spaces": ["error"]
     },
     "overrides": [


### PR DESCRIPTION
To prevent the bombardment of "prettier/prettier" errors in Windows. Since Windows line endings are different from unix ones if we set "end-of-line" to auto we avoid compatibility errors using different editors such as IntelliJ-based ones.