### PR TITLE
add single quote rule

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -8,8 +8,9 @@
         "prettier/prettier": [
            "error",
            {
-              "endOfLine": "auto"
-           }
+              "endOfLine": "auto",
+              "singleQuote": true
+           } 
         ],
         "no-multi-spaces": ["error"]
     },


### PR DESCRIPTION
Interesting little issue as described [here](https://apollograph.slack.com/archives/C037W68DBFS/p1705949195025609) ...

- The `trevorblades/eslint-config` package we inherit from sets `singleQuote` as the standard: https://github.com/trevorblades/eslint-config/blob/main/index.js
- However, `prettier` by default deactivates this and has just started screaming when we use single quotes instead of double.


The (good? bad?) bandaid for now is to just add the `singleQuote` rule to the prettier config in this project.

```
"singleQuote": true
```

Alternatively - I notice that the `final/client/.eslintrc.json` file _does not_ include any sort of prettier rules. Can we just remove? Why did we add them in the first place?